### PR TITLE
Restructure error handling for proper status codes

### DIFF
--- a/errs/errs.go
+++ b/errs/errs.go
@@ -1,8 +1,32 @@
 package errs
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	ErrFileExtensionNotAllowed error = errors.New("File extension is not allowed")
 	ErrNoFileExtension         error = errors.New("File has no extension")
+
+	ErrNotAdmin           error = errors.New("Admin permission required")
+	ErrNotModerator       error = errors.New("Moderator permissions required")
+	ErrNotUser            error = errors.New("User permissions required")
+	ErrNotCourseAdmin     error = errors.New("Course admin permissions required")
+	ErrNotCourseModerator error = errors.New("Course moderator permissions required")
+	ErrNotCourseUser      error = errors.New("Course user permissions required")
+
+	ErrParameterConversion error = errors.New("Unable to convert parameter item")
+	ErrNoQuery             error = errors.New("Unable to find query parameter")
+	ErrRawData             error = errors.New("Unable to get raw data from request")
+	ErrNoFileInRequest     error = errors.New("Unable to find file in request")
+	ErrBodyConversion      error = errors.New("Unable to convert body")
 )
+
+func Wrap(err error, s string) error {
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("%s: %w", s, err)
+}

--- a/errs/errs.go
+++ b/errs/errs.go
@@ -2,7 +2,6 @@ package errs
 
 import (
 	"errors"
-	"fmt"
 )
 
 var (
@@ -22,11 +21,3 @@ var (
 	ErrNoFileInRequest     error = errors.New("Unable to find file in request")
 	ErrBodyConversion      error = errors.New("Unable to convert body")
 )
-
-func Wrap(err error, s string) error {
-	if err == nil {
-		return nil
-	}
-
-	return fmt.Errorf("%s: %w", s, err)
-}


### PR DESCRIPTION
The method `handleApiError` has been introduced which takes the
`gin.Context` and `error` and sets the HTTP status code as well as the
body of the response depending on the `error` given in order to reply
with the correct HTTP status codes instead of mostly replying with
`500`.

Closes: https://github.com/LearningBay24/LearningBay24-backend/issues/109